### PR TITLE
fix: JSON stringify 第三个参数传入2时， 会添加\n和空格，导致包体积超大

### DIFF
--- a/src/commands/import.js
+++ b/src/commands/import.js
@@ -28,7 +28,7 @@ module.exports = {
         content = content.data;
       }
       if(typeof content === 'object' && content){
-        content = JSON.stringify(content,null,2)
+        content = JSON.stringify(content)
       }
       if(!content){
         return console.error('json 数据不能为空')


### PR DESCRIPTION
同一个json文件，如果JSON.stringify第三个参数传入2的还，会插入空格和\n，导致包体积过大从而/api/open/import_data接口返回413

以下是不同参数打印出来的length，不传入2体积仅有40%
JSON.stringify(content, null, 2).length 1857523
JSON.stringify(content).length 739521
